### PR TITLE
Let `run-tests` display more `check-info`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 \#*
 .\#*
+.bak
 .DS_Store
 compiled/
 /doc/

--- a/codewars/rackunit.rkt
+++ b/codewars/rackunit.rkt
@@ -22,8 +22,8 @@
 
 
 ;;; check-info stack filter
-(define *quiet-check-infos* '(message actual excepted))
-(define *simple-check-infos* '(name location message actual excepted))
+(define *quiet-check-infos* '(message actual expected))
+(define *simple-check-infos* '(name location message actual expected))
 (define *verbose-check-infos* '(expression params))
 
 (define (check-info-stack-filter stack mode)
@@ -55,7 +55,7 @@
   (string-join lines "<:LF:>"))
 
 (define (max-name-width stack)
-  (apply max (map check-info-name-width stack)))
+  (apply max 0 (map check-info-name-width stack)))
 
 (define (check-info-name-width check-info)
   (string-length
@@ -134,10 +134,10 @@
   (or failed? here-failed?))
 
 
-;;; run-tests: test-suite * ('simple 'custom 'all) -> (void)
+;;; run-tests: test-suite * ('quiet 'simple 'custom 'all) -> (void)
 ;;; #:mode keyword argument is one of 'simple, 'custom and 'all,
 ;;; it controls how to display the check-info stack.
-;;;   'quiet mode displays message, actual, and excepted;
+;;;   'quiet mode displays message, actual, and expected;
 ;;;   'simple mode displays all in 'quiet mode and name and location;
 ;;;   'custom mode displays all in 'simple mode and user customed check-info;
 ;;;   'all mode displays the whole check-info stack.

--- a/codewars/rackunit.rkt
+++ b/codewars/rackunit.rkt
@@ -1,63 +1,111 @@
 #lang racket/base
 (require rackunit
          rackunit/private/check-info
-         racket/string)
+         racket/list
+         racket/string
+         racket/match)
 
 (provide run-tests)
 
+;;; tags
 (define (with-tag tag value)
   (format "\n<~a::>~a\n" tag (string-replace value "\n" "<:LF:>")))
 (define completed (with-tag "COMPLETEDIN" ""))
 (define passed (with-tag "PASSED" "Test Passed"))
 
 
-(define (show-exn:test:check e)
-  (format "\n<FAILED::>Expected ~v but instead got ~v\n"
-          (get-check-expected e)
-          (get-check-actual e)))
-
-(define (get-check-info-value exn name)
-  (ormap (lambda (info)
-           (and (eq? (check-info-name info) name)
-                (check-info-value info)))
-         (exn:test:check-stack exn)))
-
-(define (get-check-expected exn)
-  (pretty-info-value
-   (get-check-info-value exn 'expected)))
-(define (get-check-actual exn)
-  (pretty-info-value
-   (get-check-info-value exn 'actual)))
+;;; handle failed test output
+(define (log-exn:test:check e)
+  (with-tag "FAILED"
+    (check-info-stack->string (exn:test:check-stack e))))
 
 
-(define (show-exn e)
-  (with-tag "ERROR" (exn-message e)))
+(define (check-info-stack->string stack)
+  (define name-width (max-name-width stack))
+  (define lines
+    (flatten (map (lambda (info)
+                    (check-info->string info name-width 0))
+                  stack)))
+  (string-join lines "<:LF:>"))
+
+(define (max-name-width stack)
+  (apply max (map check-info-name-width stack)))
+
+(define (check-info-name-width check-info)
+  (string-length
+   (symbol->string
+    (check-info-name check-info))))
+
+(define *least-name-value-space* 2)
+(define *nested-indent* 2)
+
+(define (check-info->string info name-width indent-width)
+  (define name (check-info-name info))
+  (define value (check-info-value info))
+  (define name-str (info-name->string name name-width indent-width))
+
+  (match value
+    [(nested-info nested)
+     (cons (format "~a:" name-str)
+           (map (lambda (info)
+                  (check-info->string info
+                                      name-width
+                                      (+ indent-width *nested-indent*)))
+                nested))]
+    [(dynamic-info proc)
+     (check-info->string (make-check-info name (proc))
+                         name-width
+                         indent-width)]
+    [_
+     (string-append name-str
+                    (info-value->string value))]))
+
+(define (info-name->string name name-width indent-width)
+  (define name-str (symbol->string name))
+  (define indent (make-string indent-width #\space))
+  (define space (make-string
+                 (+ (- name-width (string-length name-str) indent-width)
+                    *least-name-value-space*)
+                 #\space))
+  (string-append indent name-str ":" space))
 
 
+;;; handle test rasied an error
+(define (log-raised v)
+  (with-tag "ERROR" (raised-message v)))
+
+(define (raised-message v)
+  (if (exn? v)
+      (exn-message v)
+      (format "A value other than an exception was raised: ~e" v)))
+
+
+;;; fdown, fup, fhere:
+;;;   tarverse functions using in `foldts-test-suite`
 (define (fdown suite name before after failed?)
-  (before)
   (display (with-tag "DESCRIBE" name))
+  (before)
   failed?)
 
 (define (fup suite name before after failed kid-failed?)
-  (display completed)
   (after)
+  (display completed)
   (or failed kid-failed?))
 
 (define (fhere case name action failed?)
   (when name (display (with-tag "IT" name)))
-  (define-values (result current-failed?)
+  (define-values (result here-failed?)
     (with-handlers ([exn:test:check?
                      (lambda (e)
-                       (values (show-exn:test:check e) #t))]
-                    [exn?
+                       (values (log-exn:test:check e) #t))]
+                    [(lambda (x) #t)
                      (lambda (e)
-                       (values (show-exn e) #t))])
+                       (values (log-raised e) #t))])
       (action)
       (values passed #f)))
   (display result)
   (when name (display completed))
-  (or failed? current-failed?))
+  (or failed? here-failed?))
 
 
 (define (run-tests test)

--- a/codewars/rackunit.rkt
+++ b/codewars/rackunit.rkt
@@ -22,15 +22,19 @@
 
 
 ;;; check-info stack filter
-(define *simple-check-infos* '(name location actual excepted))
+(define *quiet-check-infos* '(message actual excepted))
+(define *simple-check-infos* '(name location message actual excepted))
 (define *verbose-check-infos* '(expression params))
 
 (define (check-info-stack-filter stack mode)
   (case mode
-    [(all) stack]
+    [(quiet) (filter quiet-check-info? stack)]
     [(simple) (filter simple-check-info? stack)]
-    [(custom) (filter not-verbose-check-info? stack)]))
+    [(custom) (filter not-verbose-check-info? stack)]
+    [(all) stack]))
 
+(define (quiet-check-info? info)
+  (member info *quiet-check-infos* check-info-with-name?))
 (define (simple-check-info? info)
   (member info *simple-check-infos* check-info-with-name?))
 (define (verbose-check-info? info)
@@ -133,10 +137,11 @@
 ;;; run-tests: test-suite * ('simple 'custom 'all) -> (void)
 ;;; #:mode keyword argument is one of 'simple, 'custom and 'all,
 ;;; it controls how to display the check-info stack.
-;;;   'simple mode displays location, actual, and except;
-;;;   'custom mode displays all above and user customed check-info;
-;;;   'all mode displays the whole check-info-stack.
-(define (run-tests test #:mode [mode 'custom])
+;;;   'quiet mode displays message, actual, and excepted;
+;;;   'simple mode displays all in 'quiet mode and name and location;
+;;;   'custom mode displays all in 'simple mode and user customed check-info;
+;;;   'all mode displays the whole check-info stack.
+(define (run-tests test #:mode [mode 'quiet])
   (let ([test-result
          (foldts-test-suite fdown fup (fhere mode) #f test)])
     (when test-result (exit 1))))

--- a/codewars/rackunit.rkt
+++ b/codewars/rackunit.rkt
@@ -64,6 +64,7 @@
 
 (define *least-name-value-space* 2)
 (define *nested-indent* 2)
+(define *pretty-print-columns* 50)
 
 (define (check-info->string info name-width indent-width)
   (define name (check-info-name info))
@@ -72,7 +73,7 @@
 
   (match value
     [(nested-info nested)
-     (cons (format "~a:" name-str)
+     (cons (format "~a" name-str)
            (map (lambda (info)
                   (check-info->string info
                                       name-width

--- a/info.rkt
+++ b/info.rkt
@@ -6,5 +6,5 @@
 (define build-deps '())
 
 (define pkg-desc "Rackunit wrapper for Codewars")
-(define version "0.1")
+(define version "0.2")
 (define pkg-authors '(yfzhe))


### PR DESCRIPTION
As #2 mention, `run-tests` now only display 'actual and 'excepted `check-info`, more info like message are missing.

This PR add a #:mode keyword argument, whose value can be: 'quiet, 'simple, 'custom, and 'all.

- Quiet mode displays message, actual, and excepted;
- Simple mode displays name, location, message, actual, and excepted;
- Custom mode displays user custom `check-info`s (using `with-check-info`) and all above;
- All mode just display the whole `check-info` stack.

The default value for #:mode is 'quiet.