### PR TITLE
A new mode of run-tests

### DIFF
--- a/codewars/rackunit.rkt
+++ b/codewars/rackunit.rkt
@@ -10,7 +10,7 @@
           [run-tests
            (->* ((or/c test-case? test-suite?))
                 (#:mode (or/c 'quiet 'simple 'all (listof symbol?)))
-                void)]))
+                void?)]))
 
 ;;; tags
 (define (with-tag tag value)


### PR DESCRIPTION
As I mentioned in #5 , a new kind of argument is added, a list of symbol will be regard as the filter of  `check-info`s' name.

I deleted the 'custom mode (the new list mode is more customizable, isn't it?).  And add contract for `run-tests`. (But contract's blame is not human-friendly, maybe we need manually check the arguments.)